### PR TITLE
fix: prop-types are not so strict

### DIFF
--- a/src/content/InputList/InputList.js
+++ b/src/content/InputList/InputList.js
@@ -1,8 +1,7 @@
 import classnames from 'classnames';
-import { func, oneOf, string, arrayOf, shape, oneOfType } from 'prop-types';
+import { func, string, node } from 'prop-types';
 import React from 'react';
 import * as olt from '@lightelligence/styles';
-import { InputListItem } from './InputListItem';
 
 /**
  * Input list is a list of items, used as the body of a dropdown. Can be used
@@ -36,10 +35,7 @@ InputList.propTypes = {
    * Content of the element should always be consisted of
    * [InputListItem](/#/Components/InputListItem) components.
    */
-  children: oneOfType([
-    shape({ type: oneOf([InputListItem]) }),
-    arrayOf(shape({ type: oneOf([InputListItem]) })),
-  ]),
+  children: node,
   /**
    * Callback when the value of the input list was changed
    */

--- a/src/controls/Dropdown/Dropdown.js
+++ b/src/controls/Dropdown/Dropdown.js
@@ -1,9 +1,9 @@
 import classnames from 'classnames';
-import { string, oneOfType, shape, oneOf, arrayOf, func } from 'prop-types';
+import { string, shape, node, func } from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import * as olt from '@lightelligence/styles';
 import { Label } from '../Label';
-import { InputListItem, InputList } from '../../content/InputList';
+import { InputList } from '../../content/InputList';
 
 export const Dropdown = React.forwardRef(
   (
@@ -92,10 +92,7 @@ Dropdown.propTypes = {
    * Content of the element should always be consisted of
    * [InputListItem](/#/Components/InputListItem) components.
    */
-  children: oneOfType([
-    shape({ type: oneOf([InputListItem]) }),
-    arrayOf(shape({ type: oneOf([InputListItem]) })),
-  ]),
+  children: node,
   /**
    * The current value of the input list
    */

--- a/src/navigation/SidebarNavigation/SidebarNavigation.js
+++ b/src/navigation/SidebarNavigation/SidebarNavigation.js
@@ -1,6 +1,5 @@
-import { oneOf, arrayOf, shape, oneOfType } from 'prop-types';
+import { node } from 'prop-types';
 import React from 'react';
-import { SidebarNavigationItem } from './SidebarNavigationItem';
 
 /**
  * Sidebar navigation is the navigation for the middle of the sidebar. It
@@ -19,10 +18,7 @@ SidebarNavigation.propTypes = {
    * Content of the element should always be consisted of
    * [SidebarNavigationItem](/#/Navigation/SidebarNavigationItem) components.
    */
-  children: oneOfType([
-    shape({ type: oneOf([SidebarNavigationItem]) }),
-    arrayOf(shape({ type: oneOf([SidebarNavigationItem]) })),
-  ]),
+  children: node,
 };
 
 SidebarNavigation.defaultProps = {

--- a/src/navigation/SidebarNavigation/SidebarNavigationItem.js
+++ b/src/navigation/SidebarNavigation/SidebarNavigationItem.js
@@ -1,11 +1,10 @@
 import classnames from 'classnames';
 import { pascalize } from 'humps';
-import { string, oneOfType, shape, oneOf, arrayOf } from 'prop-types';
+import { string, node } from 'prop-types';
 import React from 'react';
 import * as olt from '@lightelligence/styles';
 import { matchPath } from 'react-router-dom';
 import { Link } from '../../content/Link';
-import { SidebarSubNavigationItem } from './SidebarSubNavigationItem';
 
 /**
  * Navigation item for the [SidebarNavigation](#/Navigation/SidebarNavigation)
@@ -80,10 +79,7 @@ SidebarNavigationItem.propTypes = {
    * [SidebarSubNavigationItem](/#/Navigation/SidebarSubNavigationItem)
    * components.
    */
-  children: oneOfType([
-    shape({ type: oneOf([SidebarSubNavigationItem]) }),
-    arrayOf(shape({ type: oneOf([SidebarSubNavigationItem]) })),
-  ]),
+  children: node,
 };
 
 SidebarNavigationItem.defaultProps = {

--- a/src/navigation/SidebarSelector/SidebarSelectorFilter.js
+++ b/src/navigation/SidebarSelector/SidebarSelectorFilter.js
@@ -1,16 +1,7 @@
-import {
-  bool,
-  arrayOf,
-  func,
-  oneOf,
-  oneOfType,
-  shape,
-  string,
-} from 'prop-types';
+import { bool, func, node, string } from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import * as olt from '@lightelligence/styles';
-import { SidebarSelectorFilterItem } from './SidebarSelectorFilterItem';
 
 /**
  * Sidebar selector is a selector component that is used in the Sidebar to
@@ -56,10 +47,7 @@ SidebarSelectorFilter.propTypes = {
    * must be of
    * [SidebarSelectorFilterItem](#/Navigation/SidebarSelectorFilterItem) type.
    */
-  children: oneOfType([
-    shape({ type: oneOf([SidebarSelectorFilterItem]) }),
-    arrayOf(shape({ type: oneOf([SidebarSelectorFilterItem]) })),
-  ]).isRequired,
+  children: node.isRequired,
   /**
    * The title of this component
    */


### PR DESCRIPTION
I decided to loose the propTypes on some of the components, since when the component is wrapped ( e.g. *Styled Component* ) there is always a warning for not matching the prop type.