### PR TITLE
fix: disable wrapping for forward refs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14885,9 +14885,9 @@
       }
     },
     "react-is": {
-      "version": "16.10.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
-      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
     },
     "react-router": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "humps": "^2.0.1",
     "prop-types": "^15.6.2",
     "react-circular-progressbar": "^2.0.3",
+    "react-is": "^16.12.0",
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {

--- a/src/content/BasicCardTable/BasicCardTableCardItem.js
+++ b/src/content/BasicCardTable/BasicCardTableCardItem.js
@@ -1,5 +1,6 @@
-import React, { Fragment, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import * as olt from '@lightelligence/styles';
+import { isForwardRef, isFragment } from 'react-is';
 import { node, bool, shape, string, oneOf } from 'prop-types';
 import classnames from 'classnames';
 import { BasicCardTableTitle } from './BasicCardTableTitle';
@@ -9,8 +10,12 @@ const contentRequiresWrapping = (children) => {
   if (Array.isArray(children)) {
     return contentRequiresWrapping(children[0]);
   }
-  if (children.type === Fragment) {
+  if (isFragment(children)) {
     return contentRequiresWrapping(children.props.children);
+  }
+
+  if (isForwardRef(children)) {
+    return false;
   }
 
   return !children.type || children.type !== BasicCardTableContent;

--- a/src/content/BasicCardTable/BasicCardTableCardItem.test.js
+++ b/src/content/BasicCardTable/BasicCardTableCardItem.test.js
@@ -54,6 +54,20 @@ describe('BasicCardTableItem', () => {
     ).toBeTruthy();
   });
 
+  test('renders forwardRef of content', async () => {
+    const Content = React.forwardRef((props, ref) => (
+      <BasicCardTableContent {...props}>Foo</BasicCardTableContent>
+    ));
+
+    const { container } = renderCardItem({
+      children: <Content />,
+    });
+
+    expect(
+      container.querySelectorAll(`.${oltStyles.CardTableContent}`).length,
+    ).toBe(1);
+  });
+
   test('renders array of content children', async () => {
     const { container } = renderCardItem({
       children: [


### PR DESCRIPTION
This is a bit tricky.

We have two options. Either we merge this and pretend we didn't support properly the forwardRef wrapping ( `bug` ) or we wait for a Major bump ( `2.0.0` ) where as a breaking change we remove the whole wrapping of the card completely.

IMO the auto wrapping is useless, since it also doesn't check for `memo` components, Contexts, etc. 

It would be quite difficult to make it happen and the benefit for the user is not so great.